### PR TITLE
IncluiDefineMax.cpp

### DIFF
--- a/modificar.cpp
+++ b/modificar.cpp
@@ -1,4 +1,6 @@
 #include <iostream>
+#include <string.h>
+#define MAX 100
 using namespace std;
 
 int main(int argc, char *argv[]) {


### PR DESCRIPTION
faltaba definir el tamaño maximo del vector

